### PR TITLE
Add support for credentials callback

### DIFF
--- a/sigv4/sigv4.go
+++ b/sigv4/sigv4.go
@@ -18,6 +18,7 @@
 package sigv4
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -25,14 +26,24 @@ import (
 	"github.com/gocql/gocql"
 )
 
-// Authenticator for AWS Integration
-// these are exposed publicly to allow for easy initialization and go standard changing after the fact.
-type AwsAuthenticator struct {
-	Region          string
+type SigV4Credentials struct {
 	AccessKeyId     string
 	SecretAccessKey string
 	SessionToken    string
-	currentTime     time.Time // this is mainly used for testing and not exposed
+}
+
+// Callback used to retrieve V4 credentials, can be used with refreshable credentials
+type SigV4CredentialsCallback func() (SigV4Credentials, error)
+
+// Authenticator for AWS Integration
+// these are exposed publicly to allow for easy initialization and go standard changing after the fact.
+type AwsAuthenticator struct {
+	Region              string
+	AccessKeyId         string
+	SecretAccessKey     string
+	SessionToken        string
+	CredentialsCallback SigV4CredentialsCallback
+	currentTime         time.Time // this is mainly used for testing and not exposed
 }
 
 // looks up AWS_DEFAULT_REGION, and falls back to AWS_REGION for Lambda compatibility
@@ -55,16 +66,24 @@ func NewAwsAuthenticator() AwsAuthenticator {
 		SessionToken:    os.Getenv("AWS_SESSION_TOKEN")}
 }
 
+// initializes authenticator with the provided region and credentials callback
+func NewAwsAuthenticatorWithCredentialCallback(region string, callback SigV4CredentialsCallback) AwsAuthenticator {
+	return AwsAuthenticator{
+		Region:              region,
+		CredentialsCallback: callback}
+}
+
 func (p AwsAuthenticator) Challenge(req []byte) ([]byte, gocql.Authenticator, error) {
 	var resp []byte = []byte("SigV4\000\000")
 
 	// copy these rather than use a reference due to how gocql creates connections (its just
 	// safer if everything if a fresh copy).
 	auth := signingAuthenticator{region: p.Region,
-		accessKeyId:     p.AccessKeyId,
-		secretAccessKey: p.SecretAccessKey,
-		sessionToken:    p.SessionToken,
-		currentTime:     p.currentTime}
+		accessKeyId:         p.AccessKeyId,
+		secretAccessKey:     p.SecretAccessKey,
+		sessionToken:        p.SessionToken,
+		credentialsCallback: p.CredentialsCallback,
+		currentTime:         p.currentTime}
 	return resp, auth, nil
 }
 
@@ -74,11 +93,12 @@ func (p AwsAuthenticator) Success(data []byte) error {
 
 // this is the internal private authenticator we actually use
 type signingAuthenticator struct {
-	region          string
-	accessKeyId     string
-	secretAccessKey string
-	sessionToken    string
-	currentTime     time.Time
+	region              string
+	accessKeyId         string
+	secretAccessKey     string
+	sessionToken        string
+	credentialsCallback SigV4CredentialsCallback
+	currentTime         time.Time
 }
 
 func (p signingAuthenticator) Challenge(req []byte) ([]byte, gocql.Authenticator, error) {
@@ -93,8 +113,21 @@ func (p signingAuthenticator) Challenge(req []byte) ([]byte, gocql.Authenticator
 		t = time.Now().UTC()
 	}
 
-	signedResponse := internal.BuildSignedResponse(p.region, nonce, p.accessKeyId,
-		p.secretAccessKey, p.sessionToken, t)
+	accessKeyId := p.accessKeyId
+	secretAccessKey := p.secretAccessKey
+	sessionToken := p.sessionToken
+	if p.credentialsCallback != nil {
+		credentials, err := p.credentialsCallback()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to retrieve AWS credentials: %w", err)
+		}
+		accessKeyId = credentials.AccessKeyId
+		secretAccessKey = credentials.SecretAccessKey
+		sessionToken = credentials.SessionToken
+	}
+
+	signedResponse := internal.BuildSignedResponse(p.region, nonce, accessKeyId,
+		secretAccessKey, sessionToken, t)
 
 	// copy this to a sepearte byte array to prevent some slicing corruption with how the framer object works
 	resp := make([]byte, len(signedResponse))

--- a/sigv4/sigv4_test.go
+++ b/sigv4/sigv4_test.go
@@ -17,6 +17,7 @@
 package sigv4
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -67,4 +68,33 @@ func buildStdTarget() *AwsAuthenticator {
 		SecretAccessKey: "UserSecretKey-1"}
 	target.currentTime, _ = time.Parse(time.RFC3339, "2020-06-09T22:41:51Z")
 	return &target
+}
+
+func TestCallback(t *testing.T) {
+	callback := func() (SigV4Credentials, error) {
+		return SigV4Credentials{
+			AccessKeyId:     "UserID-1",
+			SecretAccessKey: "UserSecretKey-1",
+		}, nil
+	}
+	target := NewAwsAuthenticatorWithCredentialCallback("us-west-2", callback)
+	target.currentTime, _ = time.Parse(time.RFC3339, "2020-06-09T22:41:51Z")
+
+	_, challenger, _ := target.Challenge(nil)
+
+	resp, _, _ := challenger.Challenge(stdNonce)
+	expected := "signature=7f3691c18a81b8ce7457699effbfae5b09b4e0714ab38c1292dbdf082c9ddd87,access_key=UserID-1,amzdate=2020-06-09T22:41:51.000Z"
+	assert.Equal(t, expected, string(resp))
+}
+
+func TestCallbackError(t *testing.T) {
+	callback := func() (SigV4Credentials, error) {
+		return SigV4Credentials{}, fmt.Errorf("bad error")
+	}
+	target := NewAwsAuthenticatorWithCredentialCallback("us-west-2", callback)
+	target.currentTime, _ = time.Parse(time.RFC3339, "2020-06-09T22:41:51Z")
+
+	_, challenger, _ := target.Challenge(nil)
+	_, _, err := challenger.Challenge(stdNonce)
+	assert.Error(t, err, "failed to retrieve AWS credentials: bad error")
 }


### PR DESCRIPTION
*Description of changes:*

This allows the plugin to be used with refreshable credential providers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
